### PR TITLE
Fix syntax error in LG crawler

### DIFF
--- a/lg_crawler.py
+++ b/lg_crawler.py
@@ -262,10 +262,6 @@ class LGCrawlerV6:
         """특정 조합의 요금제 수집"""
         try:
             driver.get(self.base_url)
-             # ── 여기에 추가 ──
-    with open('debug_home.html', 'w', encoding='utf-8') as f:
-        f.write(driver.page_source)
-    # ─────────────────
             time.sleep(2)
             
             # 가입유형 선택


### PR DESCRIPTION
## Summary
- remove stray debug code from `lg_crawler.py`

## Testing
- `python -m py_compile lg_crawler.py`
- `python lg_crawler.py --test` *(fails: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_b_684520eafc8c832bac8e96dc1aad5944